### PR TITLE
Target `jsx` nodes; compatibility with `gatsby-plugin-mdx`

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,7 @@ module.exports = async ({ markdownAST: mdast, markdownNode, files, getNode, repo
 
   if (['fluid', 'fixed', 'resize'].indexOf(sharpMethod) < 0) reporter.panic(`'sharpMethod' only accepts 'fluid', 'fixed' or 'resize', got ${sharpMethod} instead.`);
 
-  const targetNodes = selectAll('html', mdast);
+  const targetNodes = selectAll('html, jsx', mdast);
   return Promise.all(targetNodes.map(async node => {
     if (!node.value) return;
     if (!node.value.includes(`<${componentName}`)) return;


### PR DESCRIPTION
I was trying to use this plugin with https://github.com/gatsbyjs/gatsby/tree/master/packages/gatsby-plugin-mdx, but images weren't rendering.

Not sure exactly what changed to break this, but I fixed it with my config by transforming the `jsx` nodes rather than just `html`. 

I'm afraid I'm not so familiar with the gatsby plugin system to understand what caused it to break, but i'll leave this solution here in case anyone else runs into this problem.

Right now this PR is published on NPM `@hitchcott/gatsby-remark-custom-image-component`.

**I don't know if this breaks the old behaviour.**

Gatsby Config:

```
    {
      resolve: 'gatsby-plugin-mdx',
      options: {
        extensions: ['.mdx', '.md'],
        // https://github.com/gatsbyjs/gatsby/issues/15486#issuecomment-510153237
        plugins: ['gatsby-remark-images'],
        gatsbyRemarkPlugins: [
          {
            resolve: 'gatsby-remark-images',
            options: {
              maxWidth: 1200,
              linkImagesToOriginal: true
            }
          },
          {
            resolve: 'gatsby-remark-custom-image-component',
            options: {
              // plugin options
              componentName: 'image-wrapper',
              imagePropName: 'src',
              sharpMethod: 'fluid',
              // fluid's arguments
              quality: 50,
              maxWidth: 1000
            }
          }
        ]
      }
    },

```